### PR TITLE
Fix sortActs variable references

### DIFF
--- a/poe/script.js
+++ b/poe/script.js
@@ -201,8 +201,8 @@ function buildTableForTLDR(data) {
         const actsNumberA = parseInt(a.act.match(/\d+/), 10);
         const actsNumberB = parseInt(b.act.match(/\d+/), 10);
 
-        if (actNumberA !== actNumberB) {
-            return actNumberA - actNumberB;
+        if (actsNumberA !== actsNumberB) {
+            return actsNumberA - actsNumberB;
         }
         return a.step - b.step;
     };

--- a/poe2/script.js
+++ b/poe2/script.js
@@ -201,8 +201,8 @@ function buildTableForTLDR(data) {
         const actsNumberA = parseInt(a.act.match(/\d+/), 10);
         const actsNumberB = parseInt(b.act.match(/\d+/), 10);
 
-        if (actNumberA !== actNumberB) {
-            return actNumberA - actNumberB;
+        if (actsNumberA !== actsNumberB) {
+            return actsNumberA - actsNumberB;
         }
         return a.step - b.step;
     };


### PR DESCRIPTION
## Summary
- fix incorrect variable names in sortActs function

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6862d2e745c4832499383a3dc6b3db19