### PR TITLE
Add Jest test for parseCsvRow utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,12 @@
 {
   "devDependencies": {
-    "@fullhuman/postcss-purgecss": "^5.0.0"
+    "@fullhuman/postcss-purgecss": "^5.0.0",
+    "jest": "^29.7.0"
   },
   "dependencies": {
     "prettier": "^3.2.5"
+  },
+  "scripts": {
+    "test": "jest"
   }
 }

--- a/poe/__tests__/parseCsvRow.test.js
+++ b/poe/__tests__/parseCsvRow.test.js
@@ -1,0 +1,17 @@
+const parseCsvRow = require('../parseCsvRow');
+
+test('simple comma separated values', () => {
+    expect(parseCsvRow('a,b,c')).toEqual(['a', 'b', 'c']);
+});
+
+test('quoted values with commas', () => {
+    expect(parseCsvRow('a,"b,c",d')).toEqual(['a', 'b,c', 'd']);
+});
+
+test('escaped quotes within value', () => {
+    expect(parseCsvRow('"a""a",b')).toEqual(['a"a', 'b']);
+});
+
+test('values trimmed of spaces', () => {
+    expect(parseCsvRow(' " a " , b ')).toEqual(['a', 'b']);
+});

--- a/poe/parseCsvRow.js
+++ b/poe/parseCsvRow.js
@@ -1,0 +1,12 @@
+function parseCsvRow(row) {
+    const regex = /(?:^|,)(\"(?:[^\"]*(?:\"\"[^\"]*)*)\"|[^,]*)/g;
+    let columns = [];
+    let match;
+    while (match = regex.exec(row)) {
+        let column = match[1].replace(/^"|"$/g, '').replace(/""/g, '"');
+        columns.push(column.trim());
+    }
+    return columns;
+}
+
+module.exports = parseCsvRow;


### PR DESCRIPTION
## Summary
- add Jest dev dependency and a test script
- expose `parseCsvRow` helper for use in tests
- create Jest tests for CSV row parsing

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862d2faad8483248045b6bdd35db919